### PR TITLE
Add normalization methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@
 |      | weight_decay | [0.0](https://docs.chainer.org/en/stable/reference/generated/chainer.optimizers.Adam.html) | [0.0](https://pytorch.org/docs/stable/optim.html#torch.optim.Adam) | [No args](https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer)|
 |      | amsgrad | [False](https://docs.chainer.org/en/stable/reference/generated/chainer.optimizers.Adam.html) | [False](https://pytorch.org/docs/stable/optim.html#torch.optim.Adam) | [No args](https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer)|
 
+## Normalizations
+
+| Object names in Chainer | Parameter names in Chainer | Chainer     | PyTorch     | TensorFlow     |
+|:----------------------- |:---------------------------|:-----------:|:-----------:|:--------------:|
+| BatchNormalization | eps | [2e-05](https://docs.chainer.org/en/stable/reference/generated/chainer.links.BatchNormalization.html) | [1e-05](https://pytorch.org/docs/stable/nn.html#batchnorm2d) |[1e-03](https://www.tensorflow.org/api_docs/python/tf/layers/batch_normalization)|
+| LayerNormalization | eps | [1e-06](https://docs.chainer.org/en/stable/reference/generated/chainer.links.LayerNormalization.html) | [1e-05](https://pytorch.org/docs/stable/nn.html#layernorm) | No args ([1e-12](https://github.com/tensorflow/tensorflow/blob/a6d8ffae097d0132989ae4688d224121ec6d8f35/tensorflow/contrib/layers/python/layers/layers.py#L2314)) |
+| GroupNormalization | eps | [1e-05](https://docs.chainer.org/en/stable/reference/generated/chainer.links.GroupNormalization.html) | [1e-05](https://pytorch.org/docs/stable/nn.html#groupnorm) | [1e-06](https://www.tensorflow.org/api_docs/python/tf/contrib/layers/group_norm)|
+|                    | groups | [Required](https://docs.chainer.org/en/stable/reference/generated/chainer.links.GroupNormalization.html) | [Required](https://pytorch.org/docs/stable/nn.html#groupnorm) | [32](https://www.tensorflow.org/api_docs/python/tf/contrib/layers/group_norm)|
+| local_response_normalization | n | [5](https://docs.chainer.org/en/stable/reference/generated/chainer.functions.local_response_normalization.html#chainer.functions.local_response_normalization) | [Required](https://pytorch.org/docs/stable/nn.html?highlight=local_response_norm#torch.nn.LocalResponseNorm) | [5](https://www.tensorflow.org/api_docs/python/tf/nn/local_response_normalization)|
+|                              | k | [2](https://docs.chainer.org/en/stable/reference/generated/chainer.functions.local_response_normalization.html#chainer.functions.local_response_normalization) | [1](https://pytorch.org/docs/stable/nn.html?highlight=local_response_norm#torch.nn.LocalResponseNorm) | [1](https://www.tensorflow.org/api_docs/python/tf/nn/local_response_normalization)|
+|                              | alpha | [1e-04](https://docs.chainer.org/en/stable/reference/generated/chainer.functions.local_response_normalization.html#chainer.functions.local_response_normalization) | [1e-04](https://pytorch.org/docs/stable/nn.html?highlight=local_response_norm#torch.nn.LocalResponseNorm) | [1](https://www.tensorflow.org/api_docs/python/tf/nn/local_response_normalization)|
+|                              | beta | [0.75](https://docs.chainer.org/en/stable/reference/generated/chainer.functions.local_response_normalization.html#chainer.functions.local_response_normalization) | [0.75](https://pytorch.org/docs/stable/nn.html?highlight=local_response_norm#torch.nn.LocalResponseNorm) | [0.5](https://www.tensorflow.org/api_docs/python/tf/nn/local_response_normalization)|
+
 ## Rules
 ### Kinds of symbols
 - None: default value is None.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 |      | weight_decay | [0.0](https://docs.chainer.org/en/stable/reference/generated/chainer.optimizers.Adam.html) | [0.0](https://pytorch.org/docs/stable/optim.html#torch.optim.Adam) | [No args](https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer)|
 |      | amsgrad | [False](https://docs.chainer.org/en/stable/reference/generated/chainer.optimizers.Adam.html) | [False](https://pytorch.org/docs/stable/optim.html#torch.optim.Adam) | [No args](https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer)|
 
-## Normalizations
+## Normalization methods
 
 | Object names in Chainer | Parameter names in Chainer | Chainer     | PyTorch     | TensorFlow     |
 |:----------------------- |:---------------------------|:-----------:|:-----------:|:--------------:|


### PR DESCRIPTION
I added the default values of normalization layers/functions. 

The normalization methods in this PR are:
- batch normalization
- layer normalization
- group normalization
- local response normalization

There are both trainable methods (layers in chainer) and non-trainable ones (functions in chainer) in normalization, and I made a new section "Normalization methods." 